### PR TITLE
pass a function to get IP when proxied

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,8 +17,13 @@ module.exports = function geoip( options ) {
     }
 
     return function *geolocate( next ) {
-        var ip = this.ip.match( /[^:]*$/ )[ 0 ];
-
+        var ip;
+        if (opts.ip) {
+          ip = opts.ip.bind(this)();
+        }
+        else {
+          ip = this.ip.match( /[^:]*$/ )[ 0 ];
+        }
         try {
             this.geo = countries.getGeoDataSync( ip || this.ip ) || {};
         } catch ( err ) {


### PR DESCRIPTION
When a koa app is the backend, `this.ip` is often not very useful since it is the frontend proxy IP. This patch allows passing a function which retrieves the correct value, usually from a header named `X-Forwarded-For`.

LiveScript example (`geolocate` is the middleware for koa):

```
geolocate = geoip {
  db: \./shared/geo/city.mmdb
  ip: (-> @request.header[\x-forwarded-for])
}
```
